### PR TITLE
Unit tests in TrustevMultipleMerchantSiteClientTests are skipped when irrelevant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.2</version>
+			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -90,7 +90,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.9</version>
+			<version>2.9</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/com/trustev/integration/TrustevClientTest.java
+++ b/src/test/java/com/trustev/integration/TrustevClientTest.java
@@ -104,20 +104,14 @@ public class TrustevClientTest {
         if (userName == null || password == null || secret == null || (baseUrl == null && alternateUrl == null)) {
             throw new Exception("Inexisting or invalid credentials provided.");
         }
-    }
 
-    @Before
-    public void testSetup() {
+        ApiClient.removeAllMerchantSites();
+
         if (alternateUrl != null && alternateUrl != "") {
             ApiClient.SetUp(userName, password, secret, alternateUrl);
         } else if (baseUrl != null) {
             ApiClient.SetUp(userName, password, secret, baseUrl);
         }
-    }
-
-    @After
-    public void testTeardown() {
-        ApiClient.removeAllMerchantSites();
     }
 
     @Test

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -5,15 +5,15 @@ userName=
 password=
 secret=
 url=
-
-#Optional: Full Api endpoint
+#Optional: If EU or US not provided as url, then full Api endpoint can be provided below
 altUrl=
+
+
 
 #If you're testing two Merchant sites with the ApiClient, credentials are also required for these lines
 userName2=
 password2=
 secret2=
 url2=
-
-#Optional - Full Api endpoint
+#Optional - If EU or US not provided as url2, then full Api endpoint can be provided below
 altUrl2=


### PR DESCRIPTION
Fixed unit test setups so that tests in TrustevMultipleMerchantSiteClientTests are skipped when only one set of credentials are setup through mvn parameters or config.properites (or when usernames are not unique for user 1 and user 2).

Also had to update the JUnit version to 4.12 in order for testing assumptions to work as designed.